### PR TITLE
Miscellaneous fixes

### DIFF
--- a/dev/housekeeping/dirio.py
+++ b/dev/housekeeping/dirio.py
@@ -61,7 +61,7 @@ class dirio:
   # Given a configuration, the dirfiles are opened.
   def dirsetup(self):
     self.creationtime = time.time()
-    dirname = os.path.join(self.path, datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S'))
+    dirname = os.path.join(self.path, datetime.datetime.utcnow().strftime('%Y-%m-%d-%H-%M-%S'))
 
     try:
       os.makedirs(dirname)

--- a/dev/housekeeping/insio.py
+++ b/dev/housekeeping/insio.py
@@ -22,7 +22,8 @@ class insio:
     self.autostart = autostart
     
     #self.stream = serial.serial_for_url(url=stream, baudrate=baud, stopbits=2, rtscts=1, timeout = 2, do_not_open=True)
-    self.stream  = serial.Serial(port=stream, baudrate=baud, stopbits=2, rtscts=1, timeout = 2) # Connect to instrument VCP
+    self.stream  = serial.Serial(port=None, baudrate=baud, stopbits=2, rtscts=1, timeout = 2) # Connect to instrument VCP
+    self.stream.port = stream
     self.pktsize = pktsize # STD size of COBS package
     self.thread = threading.Thread(target=self.findpkts,args=())
     

--- a/dev/scripts/odin.py
+++ b/dev/scripts/odin.py
@@ -129,7 +129,7 @@ def main():
 				ns = True)
 	if hostname == 'missw':
 		print time.strftime('%H%m.%S %d:%m:%Y',time.gmtime()) + ' ::: Odin [Status]: The host has identified herself as MissW!'
-		odin = Odin('/mnt/uranus/missw/rawdata/diodes', '/mnt/uranus/missw/conf.txt', '/mnt/uranus/missw/current/diode', '/dev/ttyUSB1', 1250000)
+		odin = Odin('/mnt/uranus/missw/rawdata/diodes', '/mnt/uranus/missw/conf.txt', '/mnt/uranus/missw/current/diode', '/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AM01YE50-if00-port0', 1250000)
 		Pyro4.config.HOST = "192.168.0.68"
 		Pyro4.Daemon.serveSimple(
 				{


### PR DESCRIPTION
It turns out that pySerial always opened the port if specified with the constructor, but didn't throw an exception before. I changed it so it doesn't open the port until `start` is called.
